### PR TITLE
Update faq on not being able to reproduce issues

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -108,6 +108,8 @@ See the complete report at file:///…/task-with-arguments_kotlin_projectInfoTas
 
 Make sure your forked repository is in sync with the `master` branch of the Gradle repository, as support for running broken tests was implemented recently.
 
+Also, note that `-PrunBrokenConfigurationCacheDocsTests=true` will only run tests that are in the list of broken tests. That means if you remove the test you are fixing from the list, you must stop using that option when running the tests, or else they will be skipped, leading to a successful build result, even if the test is still broken.
+
 
 ## Fixing Configuration Cache issues
 

--- a/workflow.md
+++ b/workflow.md
@@ -78,7 +78,7 @@ Create a draft PR with your fix, ideally annotating it with any comments that ma
 
 Please add your full name and github handle to the list of contributors in the release notes as described [here](https://github.com/gradle/gradle/blob/master/subprojects/docs/src/docs/release/notes.md?plain=1#L6).
 
-Also, don't forget to remove the tests you fixed from the list of known broken tests (see [`testsToBeFixedForConfigurationCache`](https://github.com/gradle/gradle/blob/8dc15820bb8471dac12555738ca31d238314b451/subprojects/docs/build.gradle#L753) in the docs build.gradle file). Note that once you that, you need to drop the use of  `-PrunBrokenConfigurationCacheDocsTests=true` when running the `:docsTest` task as that option ensures only tests in the list of broken tests will be run, skipping any others.
+Also, don't forget to remove the tests you fixed from the list of known broken tests (see [`testsToBeFixedForConfigurationCache`](https://github.com/gradle/gradle/blob/8dc15820bb8471dac12555738ca31d238314b451/subprojects/docs/build.gradle#L753) in the docs build.gradle file). Note that once you do that, you need to sop using `-PrunBrokenConfigurationCacheDocsTests=true` when running the `:docsTest` task as that option ensures only tests in the list of broken tests will be run, skipping any others.
 
 For bonus points, consider generating the [documentation locally](faq.md#how-to-build-the-docs-locally-so-i-can-find-and-fix-consistency-issues-with-the-prose) and reviewing (and adjusting) the prose that surrounds the snippets you changed to ensure they remain consistent with your changes.
 

--- a/workflow.md
+++ b/workflow.md
@@ -78,7 +78,7 @@ Create a draft PR with your fix, ideally annotating it with any comments that ma
 
 Please add your full name and github handle to the list of contributors in the release notes as described [here](https://github.com/gradle/gradle/blob/master/subprojects/docs/src/docs/release/notes.md?plain=1#L6).
 
-Also, don't forget to remove the tests you fixed from the list of known broken tests (see [`testsToBeFixedForConfigurationCache`](https://github.com/gradle/gradle/blob/8dc15820bb8471dac12555738ca31d238314b451/subprojects/docs/build.gradle#L753) in the docs build.gradle file).
+Also, don't forget to remove the tests you fixed from the list of known broken tests (see [`testsToBeFixedForConfigurationCache`](https://github.com/gradle/gradle/blob/8dc15820bb8471dac12555738ca31d238314b451/subprojects/docs/build.gradle#L753) in the docs build.gradle file). Note that once you that, you need to drop the use of  `-PrunBrokenConfigurationCacheDocsTests=true` when running the `:docsTest` task as that option ensures only tests in the list of broken tests will be run, skipping any others.
 
 For bonus points, consider generating the [documentation locally](faq.md#how-to-build-the-docs-locally-so-i-can-find-and-fix-consistency-issues-with-the-prose) and reviewing (and adjusting) the prose that surrounds the snippets you changed to ensure they remain consistent with your changes.
 


### PR DESCRIPTION
Explain `-PrunBrokenConfigurationCacheDocsTests=true` should be dropped once test is removed from list of broken tests